### PR TITLE
Fix Perch2 gpu device string and forward() default targets

### DIFF
--- a/bioacoustics_model_zoo/perch_v2.py
+++ b/bioacoustics_model_zoo/perch_v2.py
@@ -260,7 +260,7 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
         samples,
         progress_bar=True,
         wandb_session=None,
-        targets=("logits", "embeddings", "spatial_embeddings", "spectrograms"),
+        targets=("logit", "embedding", "spatial_embedding", "spectrogram"),
         return_dfs=True,
         **dataloader_kwargs,
     ):

--- a/bioacoustics_model_zoo/perch_v2.py
+++ b/bioacoustics_model_zoo/perch_v2.py
@@ -149,13 +149,18 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
                 f"version {version} has not been tested on {device}, tested versions: {tested_versions}"
             )
 
-        try:
-            model_path = kagglehub.model_download(handle)
-            tf_model = tensorflow.saved_model.load(model_path)
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to load Perch2 model from KaggleHub at {handle}. "
-            ) from e
+        # tensorflow tends to choose the device automatically, so to manually select between CPU and GPU we need to use the tf.device
+        # context manager both when the model is loaded and when the model forward call is made
+        self.tf_device = "CPU" if self.device.type == "cpu" else "GPU"
+        self.tf = tf # since TF isn't imported globally, we have to store it's handle to use in the forward call
+        with self.tf.device(self.tf_device):
+            try:
+                model_path = kagglehub.model_download(handle)
+                tf_model = tensorflow.saved_model.load(model_path)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to load Perch2 model from KaggleHub at {handle}. "
+                ) from e
         csv_files = [
             f
             for f in (Path(model_path) / "assets").glob("*.csv")
@@ -231,7 +236,10 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
             dict with keys matching targets, values are np.arrays of outputs
         """
         data = np.array([s.data.samples for s in batch_samples], dtype=np.float32)
-        model_outputs = self.tf_model.signatures["serving_default"](inputs=data)
+
+        # call model in context manager so it actually uses the CPU (even if a GPU is available)
+        with self.tf.device(self.tf_device):
+            model_outputs = self.tf_model.signatures["serving_default"](inputs=data)
 
         if "custom_classifier_logits" in targets or self.use_custom_classifier:
             emb_tensor = torch.tensor(model_outputs["embedding"]).to(self.device)

--- a/bioacoustics_model_zoo/perch_v2.py
+++ b/bioacoustics_model_zoo/perch_v2.py
@@ -159,9 +159,8 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
 
         # tensorflow tends to choose the device automatically, so to manually select between CPU and GPU we need to use the tf.device
         # context manager both when the model is loaded and when the model forward call is made
-        self.tf_device = "CPU" if self.device.type == "cpu" else "GPU"
-        self.tf = tf # since TF isn't imported globally, we have to store it's handle to use in the forward call
-        with self.tf.device(self.tf_device):
+        self.tf_device = tf.device("CPU" if self.device.type == "cpu" else "GPU")
+        with self.tf_device:
             try:
                 model_path = kagglehub.model_download(handle)
                 tf_model = tensorflow.saved_model.load(model_path)
@@ -246,7 +245,7 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
         data = np.array([s.data.samples for s in batch_samples], dtype=np.float32)
 
         # call model in context manager so it actually uses the CPU (even if a GPU is available)
-        with self.tf.device(self.tf_device):
+        with self.tf_device:
             model_outputs = self.tf_model.signatures["serving_default"](inputs=data)
 
         # map actual output keys to expected ones

--- a/bioacoustics_model_zoo/perch_v2.py
+++ b/bioacoustics_model_zoo/perch_v2.py
@@ -99,6 +99,14 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
         opensoundscape.ml.cnn.SpectrogramClassifier.similarity_search_hoplite_db
     )
 
+    # dict mapping the keys of the Perch2 tensorflow model to the expected keys
+    model_output_key_mapping = {
+        "label":"logits",
+        "embedding":"embeddings",
+        "spatial_embedding":"spatial_embeddings",
+        "spectrogram":"spectrograms"
+    }
+
     def __init__(self, version=None, device=None):
         """initialize Perch2 BMZ model from TensorFlow Hub
 
@@ -219,7 +227,7 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
     def batch_forward(
         self,
         batch_samples,
-        targets=("embedding", "spatial_embedding", "label", "spectrogram"),
+        targets=("logits", "embeddings", "spatial_embeddings", "spectrograms"),
         avgpool=False,
     ):
         """run inference on a single batch of samples
@@ -229,7 +237,7 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
         Args:
             batch_data: np.array of audio samples, shape (batch_size, 32000*5)
             targets: tuple of str, select from
-                ['embedding', 'spatial_embedding', 'label', 'spectrogram','custom_classifier_logits']
+                ['embeddings', 'spatial_embeddings', 'labels', 'spectrograms','custom_classifier_logits']
                 - 'custom_classifier_logits' is the result of self.network() on the embeddings
             avgpool: ignored
         Returns:
@@ -241,8 +249,15 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
         with self.tf.device(self.tf_device):
             model_outputs = self.tf_model.signatures["serving_default"](inputs=data)
 
+        # map actual output keys to expected ones
+        key_mapping_dict = type(self).model_output_key_mapping
+        model_outputs = {
+            (key_mapping_dict[k] if k in key_mapping_dict.keys() else k) : v
+            for k, v in model_outputs.items()
+        }
+
         if "custom_classifier_logits" in targets or self.use_custom_classifier:
-            emb_tensor = torch.tensor(model_outputs["embedding"]).to(self.device)
+            emb_tensor = torch.tensor(model_outputs["embeddings"]).to(self.device)
             self.network.to(self.device)
             custom_classifier_logits = self.network(emb_tensor).detach().cpu().numpy()
             model_outputs["custom_classifier_logits"] = custom_classifier_logits
@@ -252,7 +267,7 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
             if self.use_custom_classifier:
                 model_outputs[-1] = model_outputs["custom_classifier_logits"]
             else:
-                model_outputs[-1] = model_outputs["label"]
+                model_outputs[-1] = model_outputs["logits"]
 
         # only retaining requested outputs
         model_outputs = {
@@ -268,7 +283,7 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
         samples,
         progress_bar=True,
         wandb_session=None,
-        targets=("logit", "embedding", "spatial_embedding", "spectrogram"),
+        targets=("logits", "embeddings", "spatial_embeddings", "spectrograms"),
         return_dfs=True,
         **dataloader_kwargs,
     ):

--- a/bioacoustics_model_zoo/perch_v2.py
+++ b/bioacoustics_model_zoo/perch_v2.py
@@ -110,7 +110,7 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
                 Note that different models are downloaded from TF Hub for GPU vs CPU usage.
                 - default [None]: uses GPU if available, otherwise CPU
                 - 'cpu': forces CPU usage
-                - 'gpu': forces GPU usage
+                - 'cuda': forces GPU usage
 
         """
         # only require tensorflow and tensorflow_hub if/when this class is used
@@ -127,8 +127,8 @@ class Perch2(TensorFlowModelWithPytorchClassifier):
 
         # which model to load depends on whether GPU is available
         if device is None:
-            device = "gpu" if torch.cuda.is_available() else "cpu"
-        if device == "gpu":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        if device in {"cuda", "xla"} :
             if version is None:
                 version = 2  # latest GPU-compatible as of Oct 2025
             tested_versions = (2,)  # as of Jan 2026


### PR DESCRIPTION
This PR fixes both issues mentioned in #50
1) The GPU device string is switched from "gpu" to "cuda" to prevent an invalid torch.device() call, and the perch2 version selection is updated as such - both "cuda" and "xla" are treated as valid GPU devices (since AMD HIP GPUs can be accessed by torch using the CUDA interface) - this could also be restricted to only "cuda"
2) the default targets for the .forward() method have been changed from `targets=("logits", "embeddings", "spatial_embeddings", "spectrograms")`  to `targets=("logit", "embedding", "spatial_embedding", "spectrogram")` to match the keys in the dict output by the TF model (otherwise it returns a dict of empty lists) 

I've tested with `device = "cpu"` and `device = "cuda"` (both supported versions of Perch2)